### PR TITLE
Adding  kid3, musicbrainz-picard casks

### DIFF
--- a/soloistrc.lyra
+++ b/soloistrc.lyra
@@ -264,7 +264,9 @@ node_attributes:
       - github-desktop
       - google-chrome
       - google-drive
+      - kid3
       - chefdk
+      - musicbrainz-picard
       - near-lock
       - netspot
 #      - google-hangouts


### PR DESCRIPTION
Adding misc MP3 tagging & ID3 utils:

- `kid3`
- `musicbrainz-picard`